### PR TITLE
Mirror of facebookincubator hsthrift PR IssueNumber 21

### DIFF
--- a/lib/cpp/HsChannel.cpp
+++ b/lib/cpp/HsChannel.cpp
@@ -4,6 +4,9 @@
 #include <if/gen-cpp2/RpcOptions_types.h>
 #include <thrift/lib/cpp2/protocol/Serializer.h>
 
+using namespace thrift::protocol;
+using namespace apache::thrift::concurrency;
+
 std::shared_ptr<ChannelWrapper>* newWrapper(InnerChannel* channel) noexcept {
   return new std::shared_ptr<ChannelWrapper>(
       std::make_shared<ChannelWrapper>(std::move(*channel)));
@@ -12,6 +15,12 @@ std::shared_ptr<ChannelWrapper>* newWrapper(InnerChannel* channel) noexcept {
 void deleteWrapper(std::shared_ptr<ChannelWrapper>* channel) noexcept {
   delete channel;
 }
+
+static_assert((int)Priority::HighImportant == (int)HIGH_IMPORTANT);
+static_assert((int)Priority::High == (int)HIGH);
+static_assert((int)Priority::Important == (int)IMPORTANT);
+static_assert((int)Priority::NormalPriority == (int)NORMAL);
+static_assert((int)Priority::BestEffort == (int)BEST_EFFORT);
 
 apache::thrift::RpcOptions getRpcOptions(
     uint8_t* rpcOptionsPtr,

--- a/lib/cpp/HsChannel.h
+++ b/lib/cpp/HsChannel.h
@@ -9,12 +9,6 @@
 
 #include <HsFFI.h>
 
-const int HIGH_IMPORTANT = apache::thrift::concurrency::HIGH_IMPORTANT;
-const int HIGH = apache::thrift::concurrency::HIGH;
-const int IMPORTANT = apache::thrift::concurrency::IMPORTANT;
-const int NORMAL = apache::thrift::concurrency::NORMAL;
-const int BEST_EFFORT = apache::thrift::concurrency::BEST_EFFORT;
-
 enum Status { SEND_ERROR, SEND_SUCCESS, RECV_ERROR, RECV_SUCCESS };
 
 struct FinishedRequest {

--- a/lib/if/RpcOptions.thrift
+++ b/lib/if/RpcOptions.thrift
@@ -3,9 +3,17 @@
 namespace cpp2 "thrift.protocol"
 namespace hs "Thrift.Protocol"
 
+enum Priority {
+  HighImportant = 0
+  High = 1
+  Important = 2
+  NormalPriority = 3
+  BestEffort = 4
+} (hs.prefix = "")
+
 struct RpcOptions {
   1: i32 timeout;
-  2: optional i32 priority;
+  2: optional Priority priority;
   3: i32 chunkTimeout;
   4: i32 queueTimeout;
   5: optional map<string, string> headers;


### PR DESCRIPTION
Mirror of facebookincubator hsthrift PR IssueNumber 21
Summary:
We were pulling in the priority constants from fbthrift, so now I'm
defining those in RpcOptions.thrift. They don't necessarily have to be
in sync with the fbthrift definitions, but I've left it that way for
now, using static_assert() in the C++ code to catch divergence (which
I guess is unlikely to happen, but it doesn't hurt to be paranoid).

Differential Revision: D26275610


